### PR TITLE
Migrate CodeQL workflow to reusable workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,52 +9,7 @@ on:
     - cron: '16 19 * * 3'
 
 jobs:
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'c-cpp' ]
-        include:
-          - SDK: "$NANOS_SDK"
-            artifact: hathor-app-nanoS
-          - SDK: "$NANOX_SDK"
-            artifact: hathor-app-nanoX
-          - SDK: "$NANOSP_SDK"
-            artifact: hathor-app-nanoSP
-    container:
-      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-legacy:latest
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-        queries: +security-and-quality
-
-    - name: Build
-      run: |
-        BOLOS_SDK=${{ matrix.SDK }} make
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
-
+  analyse:
+    name: Call Ledger CodeQL analysis
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_codeql_checks.yml@v1
+    secrets: inherit


### PR DESCRIPTION
This PR migrates the CodeQL workflow to use the centralized reusable workflow from `LedgerHQ/ledger-app-workflows`.